### PR TITLE
Use Boost 1.86 by default

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -2,7 +2,7 @@ SET(CMAKE_FIND_USE_CMAKE_SYSTEM_PATH OFF CACHE BOOL "Prevent using system paths 
 
 BA_PACKAGE_LIBRARY(zlib          v1.2.11)
 BA_PACKAGE_LIBRARY(ba-logger     v1.2.0)
-BA_PACKAGE_LIBRARY(boost         v1.78.0)
+BA_PACKAGE_LIBRARY(boost         v1.86.0)
 BA_PACKAGE_LIBRARY(fleet-protocol-interface             v2.0.0 PLATFORM_STRING_MODE any_machine NO_DEBUG ON)
 BA_PACKAGE_LIBRARY(fleet-protocol-cxx-helpers-static    v1.1.1)
 BA_PACKAGE_LIBRARY(cpprestsdk    v2.10.20)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the Boost library to version 1.86.0, potentially enhancing functionality and performance.
- **Bug Fixes**
	- Includes various improvements and bug fixes from the updated library version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->