### PR TITLE
add logging to sendStatus

### DIFF
--- a/src/bringauto/fleet_protocol/http_client/FleetApiClient.cpp
+++ b/src/bringauto/fleet_protocol/http_client/FleetApiClient.cpp
@@ -1,5 +1,8 @@
 #include <bringauto/fleet_protocol/http_client/FleetApiClient.hpp>
 #include <bringauto/fleet_protocol/http_client/settings/Constants.hpp>
+#include <bringauto-fleet-http-client-generated/ApiException.h>
+
+#include <iostream>
 
 using namespace org::openapitools::client;
 
@@ -147,6 +150,7 @@ FleetApiClient::ReturnCode FleetApiClient::sendStatus(const std::string &statusJ
 	std::error_code json_ec {};
 	const auto json = web::json::value::parse(statusJson, json_ec);
 	if(json_ec) {
+		std::cerr << "[fleet-http-client] sendStatus JSON parse error: " << json_ec.message() << "\n";
 		return ReturnCode::INVALID_ARGUMENTS;
 	}
 	payloadDataPtr_->setJson(json);
@@ -158,7 +162,13 @@ FleetApiClient::ReturnCode FleetApiClient::sendStatus(const std::string &statusJ
 	try {
 		const auto statusesRequest = deviceApi_->sendStatuses(companyName_, carName_, statuses);
 		statusesRequest.wait();
-	} catch(std::exception &) {
+	} catch(const api::ApiException &e) {
+		std::cerr << "[fleet-http-client] sendStatus API error HTTP " << e.error_code()
+		          << ": " << e.what() << " (company=" << companyName_ << ", car=" << carName_ << ")\n";
+		return ReturnCode::FAILED;
+	} catch(const std::exception &e) {
+		std::cerr << "[fleet-http-client] sendStatus failed: " << e.what()
+		          << " (company=" << companyName_ << ", car=" << carName_ << ")\n";
 		return ReturnCode::FAILED;
 	}
 	return ReturnCode::OK;


### PR DESCRIPTION
Logs JSON parse errors and HTTP error codes (via ApiException) when sendStatus fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and diagnostic logging for status reporting failures.
  * Enhanced error messages with detailed HTTP status codes and device information when communication errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->